### PR TITLE
Setting servers

### DIFF
--- a/delete.sh
+++ b/delete.sh
@@ -1,0 +1,1 @@
+aws cloudformation delete-stack --stack-name $1 --region=us-east-1

--- a/demoservers.json
+++ b/demoservers.json
@@ -1,0 +1,6 @@
+[
+    {
+        "ParameterKey": "EnvironmentName",
+        "ParameterValue": "OurDemoInfra"
+    }
+]

--- a/demoservers.yml
+++ b/demoservers.yml
@@ -78,5 +78,53 @@ Resources:
                 Ref: WebAppLaunchConfig
             MinSize: '3'
             MaxSize: '5'
-            # TargetGroupARNs:
-            #     - Ref: WebAppTargetGroup
+            TargetGroupARNs:
+                - Ref: WebAppTargetGroup
+    
+    WebAppLB:
+        Type: AWS::ElasticLoadBalancingV2::LoadBalancer
+        Properties:
+            Subnets:
+                - Fn::ImportValue: !Sub "${EnvironmentName}-PUB1-SN"
+                - Fn::ImportValue: !Sub "${EnvironmentName}-PUB2-SN"
+            SecurityGroups:
+                - Ref: LBSecGroup
+    
+    Listener:
+        Type: AWS::ElasticLoadBalancingV2::Listener
+        Properties:
+            DefaultActions:
+                - Type: forward
+                  TargetGroupArn:
+                      Ref: WebAppTargetGroup
+            LoadBalancerArn:
+                Ref: WebAppLB
+            Port: '80'
+            Protocol: HTTP
+
+    ALBListenerRule:
+        Type: AWS::ElasticLoadBalancingV2::ListenerRule
+        Properties:
+            Actions:
+                - Type: forward
+                  TargetGroupArn: !Ref 'WebAppTargetGroup'
+            Conditions:
+                - Field: path-pattern
+                  Values: [/]
+            ListenerArn: !Ref 'Listener'
+            Priority: 1
+    
+    WebAppTargetGroup:
+        Type: AWS::ElasticLoadBalancingV2::TargetGroup
+        Properties:
+            HealthCheckIntervalSeconds: 10
+            HealthCheckPath: /
+            HealthCheckProtocol: HTTP
+            HealthCheckTimeoutSeconds: 8
+            HealthyThresholdCount: 2
+            Port: 80
+            Protocol: HTTP
+            UnhealthyThresholdCount: 5
+            VpcId: 
+                Fn::ImportValue:
+                    Fn::Sub: "${EnvironmentName}-VPCID"

--- a/demoservers.yml
+++ b/demoservers.yml
@@ -1,0 +1,48 @@
+Description: >
+ Igor J.L Ndiramiye / Udacity 2022
+
+Parameters:
+    EnvironmentName:
+        Description: An environment name that will be prefixed to resource names
+        Type: String
+
+Resources:
+    LBSecGroup:
+        Type: AWS::EC2::SecurityGroup
+        Properties:
+            GroupDescription: Allow http to our load balancer
+            VpcId:
+                Fn::ImportValue:
+                    !Sub "${EnvironmentName}-VPCID"
+            SecurityGroupIngress:
+                - IpProtocol: tcp
+                  FromPort: 80
+                  ToPort: 80
+                  CidrIp: 0.0.0.0/0
+            SecurityGroupEgress:
+                - IpProtocol: tcp
+                  FromPort: 80
+                  ToPort: 80
+                  CidrIp: 0.0.0.0/0
+
+    WebServerSecGroup:
+        Type: AWS::EC2::SecurityGroup
+        Properties:
+            GroupDescription: Allow http to our hosts and SSH from local only
+            VpcId:
+                Fn::ImportValue:
+                    !Sub "${EnvironmentName}-VPCID"
+            SecurityGroupIngress:
+                - IpProtocol: tcp
+                  FromPort: 8080
+                  ToPort: 8080
+                  CidrIp: 0.0.0.0/0
+                - IpProtocol: tcp
+                  FromPort: 22
+                  ToPort: 22
+                  CidrIp: 0.0.0.0/0
+            SecurityGroupEgress:
+                - IpProtocol: tcp
+                  FromPort: 0
+                  ToPort: 65535
+                  CidrIp: 0.0.0.0/0

--- a/demoservers.yml
+++ b/demoservers.yml
@@ -34,8 +34,8 @@ Resources:
                     !Sub "${EnvironmentName}-VPCID"
             SecurityGroupIngress:
                 - IpProtocol: tcp
-                  FromPort: 8080
-                  ToPort: 8080
+                  FromPort: 80
+                  ToPort: 80
                   CidrIp: 0.0.0.0/0
                 - IpProtocol: tcp
                   FromPort: 22
@@ -46,3 +46,37 @@ Resources:
                   FromPort: 0
                   ToPort: 65535
                   CidrIp: 0.0.0.0/0
+    
+    WebAppLaunchConfig:
+        Type: AWS::AutoScaling::LaunchConfiguration
+        Properties:
+            UserData:
+                Fn::Base64: !Sub |
+                    #!/bin/bash
+                    apt-get update -y
+                    apt-get install apache2 -y
+                    systemctl start apache2.service
+                    cd /var/www/html
+                    echo "Udacity Demo Web Server Up and Running!" > index.html
+            ImageId: ami-00ddb0e5626798373
+            KeyName: newkeypairEC2
+            SecurityGroups:
+                - Ref: WebServerSecGroup
+            InstanceType: t3.small
+            BlockDeviceMappings:
+                - DeviceName: "/dev/sdk"
+                  Ebs:
+                    VolumeSize: '10'
+
+    WebAppGroup:
+        Type: AWS::AutoScaling::AutoScalingGroup
+        Properties:
+            VPCZoneIdentifier:
+                - Fn::ImportValue: 
+                    !Sub "${EnvironmentName}-PRIV-NETS"
+            LaunchConfigurationName:
+                Ref: WebAppLaunchConfig
+            MinSize: '3'
+            MaxSize: '5'
+            # TargetGroupARNs:
+            #     - Ref: WebAppTargetGroup


### PR DESCRIPTION
### Security Group
A security group defines the firewall rules, such as the protocol to open to network traffic and the set of valid IP addresses. Security groups are specific to individual resources (EC2 servers, databases) and not to subnets.
We have two Security groups:
- WebServerSecGroup for the webserver
- LBSecGroup for a load balancer
#### Ingress rules and egress rules
- Ingress rules are for inbound traffic, and egress rules are for outbound traffic.
- Ingress rules restrict or allow traffic trying to reach our resources on specific ports.
- Egress rules restrict or allow traffic originating from our server -- typically we are ok allowing all outbound traffic without restrictions as this doesn’t pose a risk for a security breach.

#### Example
The security group below with ingress/egress rules allowing traffic on port 80 using TCP protocol from/to any location:
```
InstanceSecurityGroup:
  Type: AWS::EC2::SecurityGroup
  Properties:
      GroupDescription: Allow HTTP to the client host
      VpcId:
         Ref: myVPC
      SecurityGroupIngress:
      - IpProtocol: tcp
        FromPort: 80
        ToPort: 80
        CidrIp: 0.0.0.0/0
      SecurityGroupEgress:
      - IpProtocol: tcp
        FromPort: 80
        ToPort: 80
        CidrIp: 0.0.0.0/0
```

### Autoscaling group
An Autoscaling group is a logical group of EC2 instances that share a similar configuration.

This AWS service monitors the EC2 instances and automatically adjusts the running count by adding/removing EC2 instances, ensuring that a desired number of servers (EC2 instances) are always up and running. 
- #### Scaling policy
A Scaling Policy is the criteria used to decide when to Add or Remove Servers from your Auto Scaling Group. Running the servers 24 hours a day costs money. So, It's best to have criteria/conditions, called Scaling policy, that will turn those servers off when they are not needed and then turn them back on demand.

For example, you could create a CloudWatch Alarm with a custom metric that counts the number of web visitors in the last 2 hours; if the number is less than 100, perhaps a single server is enough. This will be a trigger to Scale Down if there is more than one server running at the time.

A Scaling policy spins up/shuts down EC2 instances automatically based on certain conditions that we specify, such as:
- If an instance goes down due to any reason, such as bad health
- If an instance achieves a CPU utilization upper threshold, say 90%
- If the CPU utilization comes down below a certain lower threshold, then one of the instances will be shut down automatically

- #### Launch Configuration
Note that all the EC2 instances running as a part of an autoscaling group share a common configuration, such as AMI, instance-type, security-group, key pair, etc. All these configurations are saved in a separate resource: Launch configuration. Think of a Launch Configuration as a template or a recipe. You are instructing the Auto Scaling service HOW to run your web application.

For example, An application requires 2GB RAM, 4 vCPUs, 10GB of Disk Space, Java runtime version 8 or NodeJS 10.0. All this is on top of a standard distribution of Linux or Windows.

### What is a Load Balancer?

We learned earlier that a [load-balancer](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/introduction.html) automatically distributes incoming application traffic across multiple servers (EC2 instances). These servers need not essentially be present in a single subnet. They (servers) can span across numerous subnets in a given VPC. In our example, these servers are residing in the private subnets.

A load balancer is not exactly a part of Auto Scaling. Still, it helps answer the question: "If I am running a web application in 20 different servers, how do I set up a single point of entry that guarantees an even workload distribution across all 20 servers?" The answer is a load balancer.

A load balancer allows you to reduce your Autoscaling down to 1 server at night when very few people are using your web application, and then Scale up to 10 or more servers during the day, when hundreds or thousands may be using it. The user doesn't experience any difference in availing of the services due to auto-scaling.
### What is a Listener and Listener Rule?

A load balancer requires a listener. A [listener](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-listeners.html) is a process that checks for connection requests using the protocol and port that you specify in your code. In comparison, a listener rule determines how the load balancer routes request to the registered targets. For example, a listener for an application load balancer will route the particular request to a specific target group based on some conditions we specify, such as URL path.
### What is a Target Group?

A [target group](https://docs.aws.amazon.com/elasticloadbalancing/latest/application/load-balancer-target-groups.html) is a logical group of EC2 instances spanning across numerous subnets in a given VPC. You must explicitly register an EC2 instance with a target group, after which it will be called a target. In our example, the autoscaling group manages all EC2 instances in the target group, meaning it will automatically add/remove the instances to/from the target group.

#### Relationship between Target Groups and Auto Scaling groups.
- A load balancer is a device that simply forwards traffic, evenly across a group of servers, known as a Target Group.
- The problem is, we can’t specifically name those servers, because if they are part of an Auto Scaling group, this means that they can come and go as demand for your application increases or decreases.


